### PR TITLE
GitHub Update #4

### DIFF
--- a/base.xml
+++ b/base.xml
@@ -2,127 +2,140 @@
 
 <!-- TODO List
 
-printstack()
+IMPORTANT NOTE: Development of FGC has been discontinued due to sunset phase starting on June 24, 2021. 
+This means that I will no longer be testing this ruleset in FGC. I can only guarantee that it works in FGU.
+
 
 CRITICALLY IMPORTANT
 
+Add Targeting options.
+Fill empty space on charsheet_main. (Blood Magic items, Half-Magic tests?)
+Need to create a place for Talent Knacks.
+In Progress: Fix layout of main charsheet tab. Use correct label templates (<label> and <label_frametop> but not <label_column>)
+Possibly add Circle/Novice/Journeyman to skills/talents view.
+Add Karma Use to rolls. Talents, and based on a checkbox in/near modifier box?
+Get Combat Tracker working. In progress, Initiative Rolls, Defenses, Health, and Current Wounds are working so far. (Need to add Attacks, etc)
+Add Racial Stats to Race records, so they can be added to character sheet by dragging. (Create New Tab?)
+Get Races reference to match definitions in book.
+Get Disciplines reference to match definitions in book.
+In Progress: Allow Drag/Drop Character Creation. Race/Discipline/Talents/Skills are now working.
+Add Combat/Actions/Spells/Thread Items Tab(s) to charsheet.
+Get rolls to check for targets, and their Defenses. 
+Create "Roll Step #" widget, (similar to the Mod window or the Dice Tower) that allows you to enter a step number and roll it.
+Add Custom Ability Modifier Fields to NPC and Charsheet, to allow custom bonuses/flaws. (Other computations, such as Race, Attribute Points, Half-Magic, etc.)
+Fix layout of main charsheet tab. Use correct label templates (not label_column?)
+In Progress: Get CT Menu working (rest, etc.) Menu is working, any new nodes to add?
+Add tracker for current number of recovery tests?
+Add support for new lighting features. Default visions work without modification. Possibly need to add new visions?
+Update Talents/Skills to use dropdown for actions? Number instead of string for Strain?
+Fix NPCs so that manually entered numbers don't get overwritten by onUpdate(); (Add "Custom?" checkbox?)
+
+THEME/UI:
 FG Dark theme removes iedit buttons on client?
 
-TODO: Fill empty space on charsheet_main. (Blood Magic items, Half-Magic tests?)
-TODO: Need to create a place for Talent Knacks.
-TODO: Need to update CT to show Total Damage instead of Current. In progress. How to make it input to the correct field? (damage, stun)
-TODO: In Progress: Fix layout of main charsheet tab. Use correct label templates (<label> and <label_frametop> but not <label_column>)
-TODO: Possibly add Circle/Novice/Journeyman to skills/talents view.
-TODO: Add Karma Use to rolls. Talents, and based on a checkbox in/near modifier box?
-TODO: Get Combat Tracker working. In progress, Initiative Rolls, Defenses, Health, and Current Wounds are working so far. (Need to add Attacks, etc)
-TODO: Add Racial Stats to Race records, so they can be added to character sheet by dragging. (Create New Tab?)
-TODO: Get Races reference to match definitions in book.
-TODO: Get Disciplines reference to match definitions in book.
-TODO: In Progress: Allow Drag/Drop Character Creation. Race/Discipline/Talents/Skills are now working.
-TODO: Add Combat/Actions/Spells/Thread Items Tab(s) to charsheet.
-TODO: Get rolls to check for targets, and their Defenses. 
-TODO: Create "Roll Step #" widget, (similar to the Mod window or the Dice Tower) that allows you to enter a step number and roll it.
-TODO: Add Custom Ability Modifier Fields to NPC and Charsheet, to allow custom bonuses/flaws. (Other computations, such as Race, Attribute Points, Half-Magic, etc.)
-TODO: Fix layout of main charsheet tab. Use correct label templates (not label_column?)
-TODO: In Progress: Get CT Menu working (rest, etc.) Menu is working, any new nodes to add?
-TODO: Add tracker for current number of recovery tests?
-TODO: Add support for new lighting features. Default visions work without modification. Possibly need to add new visions?
-TODO: Update Talents/Skills to use dropdown for actions? Number instead of string for Strain?
-TODO: Fix NPCs so that manually entered numbers don't get overwritten by onUpdate(); (Add "Custom?" checkbox?)
+OPTIMIZATION:
+Verify that old FGC code isn't bogging us down.
 
 
-CONTENT
-
-DONE: Add Base Races - Finished, including links to racial abilities.
-DONE: Add Base Talents - Finished.
-DONE: Add Base Disciplines - Finished, including links to Talents.
-DONE: Add Base Skills - Finished.
-TODO: Add NPCs/Monsters from Gamemaster's Guide. Not Started. (less important?)
-TODO: Add Base Spells - In Progress: Sent Kayla spell data, will receive formatted XML file.
+CONTENT:
+Add NPCs/Monsters from Gamemaster's Guide. Not Started. (less important?)
+Add Base Spells - In Progress: Sent Kayla spell data, will receive formatted XML file.
 
 
-QUALITY OF LIFE
+QUALITY OF LIFE:
+Figure out LibraryDataED4 (data_library_ED4.lua) I think this is related to exporting races,disciplines, etc.
+Allow spells to be displayed by class, level, etc. (Data Library, aPlayerListButtons, aGMListButtons)
+Maybe we need a getStepFromDice function in Step_Action_Lookup? (reverse of getStepDice)
+Fix pronouns to use they/them instead of he/him or she/her. (talent descriptions, etc)
+Do I need a legend worksheet?
 
-TODO: Figure out LibraryDataED4 (data_library_ED4.lua) I think this is related to exporting races,disciplines, etc.
-TODO: Allow spells to be displayed by class, level, etc. (Data Library, aPlayerListButtons, aGMListButtons)
-TODO: Maybe we need a getStepFromDice function in Step_Action_Lookup? (reverse of getStepDice)
-TODO: Fix pronouns to use they/them instead of he/him or she/her. (talent descriptions, etc)
-TODO: Do I need a legend worksheet?
 
+FINISHED/FIXED:
+GitHub Update #4
+June 12, 2021:
+onResult now recognizes rolls that have "attack", "damage", or "heal" as part of the rRoll.sDesc.
+Attack rolls now report hit or miss on physical defense.
+Heal rolls now heal the target.
+Damage rolls now damage the target. (normal damage only for now).
+ActionManagerED4.pushRoll and ActionManagerED4.dragRoll now optionally accept a previously built rRoll.
+Fixed rSource being kept from previous rolls to NPC action rolls, nil if otherwise.
 
-FINISHED
+GitHub Update #3
+June 10, 2021: 
+Updated CT to show Total Damage instead of Current.
 
-DONE: Updated explosion function to roll new dice. 
-DONE: Updated Recovery Tests and Overnight Rests to account for stun damage.
-DONE: Updated Total Damage script to include Current, Stun, and BloodMagic.
-DONE: Fixed Spell Descriptions to include Area of Effect.
-DONE: Fixed additional parent info for Talent/Skill rolls.
-DONE: Added Description info for Stats onDragStart
-DONE: Fixed Talent/Skill onUpdate to make sure the shortcut exists before overwriting the name.
-DONE: Fixed languages on FGU. I think.
-DONE: Added new action types for Attack, Damage, Heal
-DONE: Updated Talents/Skills tabs on char sheet to show rank/step.
-DONE: Added defenses to CT.
-DONE: Color Dice results when they explode! Or hit the "Rule of One"!
-DONE: Added language font files for main languages.
-DONE: Added system specific effects.
-DONE: Updated GameSystem to show Grid Distance of 2. This means each hex/square is 2 yd.
-DONE: Got Spells reference to match definitions in book. Also added traits and ct effects fields for automation.
-DONE: Added max carry capacity functionality.
-DONE: Updated Skills and Talents descriptions to include dropdowns for action/cost/skilluse.
-DONE: Finished importing Talents and Skills.
-DONE: Finished updating Races and Disciplines with linked abilities.
-DONE: Added Blood Magic and Stun damage fields.
-DONE: Added Racial Abilities reference, similar to Talents/Skills to allow Drag/Drop to Races reference and Charsheet.
-DONE: Got Talents reference to match definitions in book.
-DONE: Got Skills reference to match definitions in book.
-DONE: Fixed karmaStep inside char_main.xml to be a number field, so that we can update it.
-DONE: Update MaxKarma on resting. 
-DONE: Updated Reference Sheets (Races, Talents, etc) to not use separate script files.
-DONE: Added detection of 'Step #' rolls in NPC skills.
-DONE: Fixed adding multiples of nMod. (Steps 1 and 2 only subtract their penalty once, despite explosions.)
-DONE: Fixed ModifierStack to reset upon adding to step number. This prevents adding static numbers to rolls in addition to increasing step #.
-DONE: Updated roll descriptions to include modified step numbers. 
-DONE: Verified custom templates, renamed some to add ED4. (template_ED4, ActionManagerED4, CombatManagerED4)
-DONE: Fixed overridden files to not include non-overridden content. (templates, etc)
-DONE: Added 'Senses' field for Charsheet.
-DONE: Make all Character Sheet Main tab rolls work, including doubleclicks.
-DONE: Allow doubleclick to open map where character token is currently located.
-DONE: Don't allow negative Damage/Wound values for Chars/NPCs/CT.
-DONE: Don't allow negative Karma values for Chars.
-DONE: Fixed Karma rolls to properly deduct only on valid rolls.
-DONE: Automagically heal characters based on Recovery Rolls.
-DONE: Fixed Tab Order in CT.
-DONE: Make HP boxes (current damage) allow add/drop for Charsheet and NPCs. (plus CT)
-DONE: Fixed CT Menu for Resting.
-DONE: Fixed CharacterManager.recoveryTest function.
-DONE: Created ActionManagerED4.pushRoll to make rolls without draginfo.
-DONE: Renamed ActionManagerED4.performRoll to ActionManagerED4.dragRoll
-DONE: Initiative Menu in CT now works for all types. NPCs must have their window opened before rolling initiative.
-DONE: Fix rSource on NPC rolls.
-DONE: FINALLY! Fixed "Script Error: [string "scripts/manager_image.lua"]:208: attempt to call field 'getDatabaseNode' (a nil value)"
-DONE: Reorganized the scripts files.
-DONE: Figure out how to get rSource from draginfo. SERIOUSLY!! ActionManager.decodeActors(draginfo)
-DONE: Add Current Damage and Wounds Fields to NPC records.
-DONE: Link NPC fields in CT to matching fields in NPC records.
-DONE: Fix recursive call from Charsheet Main "Stat_Step" fields.
-DONE: Update NPC Statistics to reflect stats automatically (Unconcious, Death, etc..)
-DONE: Optimize getStepDice to be formulaic.
-DONE: Remove Dice elements under Attributes, as they are no longer needed.
-DONE: Update NPC records to reflect stat blocks of monsters.
-DONE: Update numberColumn to show rollable property.
-DONE: All dice are exploding properly.
-DONE: AutoUpdate Attribute Step Values and Dice. (window.onUpdate();)
-DONE: Fixed Datasource of Skills.
-DONE: 'locked' state actually locking the window for Races, Disciplines, Talents, Skills, Spells.
-DONE: Add OnUpdate to Lock button so that it locks instantly instead of after reload.
-DONE: Make all appropriate fields update based on attributes. (Characteristics Table)
-DONE: Create Step Table, ensure it matches with ED4.
-DONE: Make sure that steps 1 and 2 have the correct modifiers (1d4-2 and 1d4-1)
-DONE: Allow modifier box to increase the step number before rolling.
-DONE: Include ED4 logo for decal options.
-DONE: Add Legend Points(XP) to Party Sheet.
-FIXED: Spelling of Obsidimen vs Obsidiman in race descriptions. (Obsidiman is singular, Obsidimen is plural.)
+Updates below this line were finished on June 9, 2021 or earlier, prior to FGC sunset.
+Updated dice explosion function to roll new dice. 
+Updated Recovery Tests and Overnight Rests to account for stun damage.
+Updated Total Damage script to include Current, Stun, and BloodMagic.
+Fixed Spell Descriptions to include Area of Effect.
+Fixed additional parent info for Talent/Skill rolls.
+Added Description info for Stats onDragStart
+Fixed Talent/Skill onUpdate to make sure the shortcut exists before overwriting the name.
+Fixed languages on FGU. I think.
+Added new action types for Attack, Damage, Heal
+Updated Talents/Skills tabs on char sheet to show rank/step.
+Added defenses to CT.
+Color Dice results when they explode! Or hit the "Rule of One"!
+Added language font files for main languages.
+Added system specific effects.
+Updated GameSystem to show Grid Distance of 2. This means each hex/square is 2 yd.
+Got Spells reference to match definitions in book. Also added traits and ct effects fields for automation.
+Added max carry capacity functionality.
+Updated Skills and Talents descriptions to include dropdowns for action/cost/skilluse.
+Finished importing Talents and Skills.
+Finished updating Races and Disciplines with linked abilities.
+Added Blood Magic and Stun damage fields.
+Added Racial Abilities reference, similar to Talents/Skills to allow Drag/Drop to Races reference and Charsheet.
+Got Talents reference to match definitions in book.
+Got Skills reference to match definitions in book.
+Fixed karmaStep inside char_main.xml to be a number field, so that we can update it.
+Update MaxKarma on resting. 
+Updated Reference Sheets (Races, Talents, etc) to not use separate script files.
+Added detection of 'Step #' rolls in NPC skills.
+Fixed adding multiples of nMod. (Steps 1 and 2 only subtract their penalty once, despite explosions.)
+Fixed ModifierStack to reset upon adding to step number. This prevents adding static numbers to rolls in addition to increasing step #.
+Updated roll descriptions to include modified step numbers. 
+Verified custom templates, renamed some to add ED4. (template_ED4, ActionManagerED4, CombatManagerED4)
+Fixed overridden files to not include non-overridden content. (templates, etc)
+Added 'Senses' field for Charsheet.
+Make all Character Sheet Main tab rolls work, including doubleclicks.
+Allow doubleclick to open map where character token is currently located.
+Don't allow negative Damage/Wound values for Chars/NPCs/CT.
+Don't allow negative Karma values for Chars.
+Fixed Karma rolls to properly deduct only on valid rolls.
+Automagically heal characters based on Recovery Rolls.
+Fixed Tab Order in CT.
+Make HP boxes (current damage) allow add/drop for Charsheet and NPCs. (plus CT)
+Fixed CT Menu for Resting.
+Fixed CharacterManager.recoveryTest function.
+Created ActionManagerED4.pushRoll to make rolls without draginfo.
+Renamed ActionManagerED4.performRoll to ActionManagerED4.dragRoll
+Initiative Menu in CT now works for all types. NPCs must have their window opened before rolling initiative.
+Fix rSource on NPC rolls.
+Fixed "Script Error: [string "scripts/manager_image.lua"]:208: attempt to call field 'getDatabaseNode' (a nil value)"
+Reorganized the scripts files.
+Figure out how to get rSource from draginfo. SERIOUSLY!! ActionManager.decodeActors(draginfo)
+Add Current Damage and Wounds Fields to NPC records.
+Link NPC fields in CT to matching fields in NPC records.
+Fix recursive call from Charsheet Main "Stat_Step" fields.
+Update NPC Statistics to reflect stats automatically (Unconcious, Death, etc..)
+Optimize getStepDice to be formulaic.
+Remove Dice elements under Attributes, as they are no longer needed.
+Update NPC records to reflect stat blocks of monsters.
+Update numberColumn to show rollable property.
+All dice are exploding properly.
+AutoUpdate Attribute Step Values and Dice. (window.onUpdate();)
+Fixed Datasource of Skills.
+'locked' state actually locking the window for Races, Disciplines, Talents, Skills, Spells.
+Add OnUpdate to Lock button so that it locks instantly instead of after reload.
+Make all appropriate fields update based on attributes. (Characteristics Table)
+Create Step Table, ensure it matches with ED4.
+Make sure that steps 1 and 2 have the correct modifiers (1d4-2 and 1d4-1)
+Allow modifier box to increase the step number before rolling.
+Include ED4 logo for decal options.
+Add Legend Points(XP) to Party Sheet.
+Fixed spelling of Obsidimen vs Obsidiman in race descriptions. (Obsidiman is singular, Obsidimen is plural.)
 
 Unused Files:
 	<includefile source="ct/template_ct.xml" />

--- a/campaign/char_main.xml
+++ b/campaign/char_main.xml
@@ -168,11 +168,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Dexterity";
+            local sType = "Dexterity";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -239,11 +239,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Strength";
+            local sType = "Strength";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <default>5</default>
@@ -310,11 +310,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Toughness";
+            local sType = "Toughness";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -381,11 +381,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Perception";
+            local sType = "Perception";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -452,11 +452,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Willpower";
+            local sType = "Willpower";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -523,11 +523,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Charisma";
+            local sType = "Charisma";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -579,6 +579,7 @@
           end
         </script>
         <readonly />
+        <delaykeyupdate />
         <default>0</default>
       </number_ED4>
       <number_ED4 name="Current_Damage" source="health.damage.value">
@@ -608,6 +609,7 @@
             end
           end
         </script>
+        <delaykeyupdate />
         <default>0</default>
       </number_ED4>
       <number_ED4 name="Current_Wounds" source="health.wounds.value">
@@ -617,6 +619,13 @@
 				</anchored>
         <min>0</min>
         <script>
+          function onValueChanged()
+            if not Global.cmUpdating then
+              Global.cmUpdating = true;
+              window.onUpdate();
+              Global.cmUpdating = false;
+            end
+          end
           function onDrop(x, y, draginfo)
             if draginfo.isType("Wound") then
               setValue(getValue() + draginfo.getNumberData());
@@ -644,7 +653,7 @@
 				</anchored>
         <static textres="char_label_blood" />
       </label>
-      <number_ED4 name="Stun_Damage" source="health.stun.value">
+      <number_ED4 name="Stun_Damage" source="health.damage.stun">
         <anchored to="CurrentHealthFrame" width="35" height="20">
           <top offset="155" />
           <left offset="20" />
@@ -671,9 +680,10 @@
             end
           end
         </script>
+        <delaykeyupdate />
         <default>0</default>
       </number_ED4>
-      <number_ED4 name="Blood_Damage" source="health.blood.value">
+      <number_ED4 name="Blood_Damage" source="health.damage.blood">
         <anchored to="CurrentHealthFrame" width="35" height="20">
           <top offset="155" />
           <left offset="70" />
@@ -688,6 +698,7 @@
             end
           end
         </script>
+        <delaykeyupdate />
         <default>0</default>
       </number_ED4>
       
@@ -944,11 +955,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "InitRoll";
+            local sType = "InitRoll";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <default>5</default>
@@ -966,11 +977,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Knockdown";
+            local sType = "Knockdown";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -1006,7 +1017,6 @@
             window.updateKarma();
           end
           function onValueChanged()
-            Debug.chat("Updating Karma Step");
             if not Global.cmUpdating then
               Global.cmUpdating = true;
               window.onUpdate();
@@ -1055,11 +1065,11 @@
             local kValue = getValue();
             if kValue > 0 then
               local karmaStep = 4;
-              local rType = "Karma";
+              local sType = "Karma";
               local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
               karmaStep = CharacterManager.getKarmaStep(nodeChar);
               local bSecretRoll = false;
-              ActionManagerED4.pushRoll(rType, karmaStep, nodeChar, bSecretRoll);
+              ActionManagerED4.pushRoll(sType, karmaStep, nodeChar, bSecretRoll);
             end
           end
         </script>
@@ -1077,11 +1087,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Recovery";
+            local sType = "Recovery";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />

--- a/campaign/char_skills.xml
+++ b/campaign/char_skills.xml
@@ -161,11 +161,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Skill";
+            local sType = "Skill";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <readonly />

--- a/campaign/char_talents.xml
+++ b/campaign/char_talents.xml
@@ -194,11 +194,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Talent";
+            local sType = "Talent";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <readonly />

--- a/campaign/record_npc.xml
+++ b/campaign/record_npc.xml
@@ -165,11 +165,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Dexterity";
+            local sType = "Dexterity";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
           function onValueChanged()
             window.onStatUpdate();
@@ -190,11 +190,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Strength";
+            local sType = "Strength";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
           function onValueChanged()
             window.onStatUpdate();
@@ -215,11 +215,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Toughness";
+            local sType = "Toughness";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
           function onValueChanged()
             window.onStatUpdate();
@@ -240,11 +240,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Perception";
+            local sType = "Perception";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
           function onValueChanged()
             window.onStatUpdate();
@@ -265,11 +265,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Willpower";
+            local sType = "Willpower";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
           function onValueChanged()
             window.onStatUpdate();
@@ -290,11 +290,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "Charisma";
+            local sType = "Charisma";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
           function onValueChanged()
             window.onStatUpdate();
@@ -318,11 +318,11 @@
             return true;
           end
           function onDoubleClick()
-            local rType = "InitRoll";
+            local sType = "InitRoll";
             local rStep = getValue();
             local nodeChar = ActorManager.resolveActor(window.getDatabaseNode());
             local bSecretRoll = false;
-            ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+            ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
           end
         </script>
         <rollable />
@@ -349,7 +349,7 @@
 				<static textres="npc_label_currentDamage" />
 			</label_column>
       
-			<number_column name="currentDamage" source="health.damage.value">
+			<number_column name="currentDamage" source="health.damage.total">
 				<default>0</default>
         <min>0</min>
         <script>

--- a/campaign/scripts/npc_roll.lua
+++ b/campaign/scripts/npc_roll.lua
@@ -20,19 +20,16 @@ function parseComponents()
 	for i = 1, #aClauses do
     --Look for Step # first.
 		local nStarts, nEnds, sMod = string.find(aClauses[i], "Step %d+");
-    --Debug.chat("Looking for Step # in NPC skills.");
+    --Looking for Step # in NPC skills.
     local sStep, sDesc = StringManager.extractPattern(aClauses[i], "Step %d+");
 		if sStep then
       local stepNum, sVerify = StringManager.extractPattern(sStep, "%d+");
       if sVerify == "Step " then
-        --Debug.chat("Found Step #: ");
         stepNum = tonumber(stepNum);
-        --Debug.chat(stepNum);
         local stepDice, nMod, stepNum = StepLookup.getStepDice(stepNum);
         local sLabel = sDesc .. " (Step " .. stepNum .. ")";
-        --Debug.chat(stepDice);
         -- Insert the possible skill into the skill list
-        table.insert(aComponents, {nStart = aClauseStats[i].startpos, nLabelEnd = aClauseStats[i].startpos + nEnds, nEnd = aClauseStats[i].endpos, sLabel = sLabel, aDice = stepDice, nMod = nMod, rStep = rStep });
+        table.insert(aComponents, {nStart = aClauseStats[i].startpos, nLabelEnd = aClauseStats[i].startpos + nEnds, nEnd = aClauseStats[i].endpos, sLabel = sLabel, aDice = stepDice, nMod = nMod, rStep = stepNum });
       else --look for "2d6+5" type dice.
         local nStarts, nEnds, sMod = string.find(aClauses[i], "([d%dF%+%-]+)%s*$");
         if nStarts then
@@ -97,8 +94,13 @@ function action(draginfo)
 	if nDragIndex then
 		if draginfo then
 			if #(aComponents[nDragIndex].aDice) > 0 then
-				local rRoll = { sType = "dice", sDesc = aComponents[nDragIndex].sLabel, aDice = aComponents[nDragIndex].aDice, nMod = aComponents[nDragIndex].nMod };
-				ActionsManager.performAction(draginfo, nil, rRoll);
+				local rRoll = { sType = "dice", sDesc = aComponents[nDragIndex].sLabel, aDice = aComponents[nDragIndex].aDice, nMod = aComponents[nDragIndex].nMod, rStep = aComponents[nDragIndex].rStep };
+        local bSecretRoll = true;
+        --need to make sure rActor has the NPC actor node.
+        local nodeChar = window.getDatabaseNode();
+        local rActor = ActorManager.resolveActor(nodeChar);
+        ActionManagerED4.dragRoll(draginfo, rRoll.sType, rStep, rActor, bSecretRoll, rRoll);
+				--ActionsManager.performAction(draginfo, nil, rRoll);
 			else
 				draginfo.setType("number");
 				draginfo.setDescription(aComponents[nDragIndex].sLabel);
@@ -107,8 +109,13 @@ function action(draginfo)
 			end
 		else
 			if #(aComponents[nDragIndex].aDice) > 0 then
-				local rRoll = { sType = "dice", sDesc = aComponents[nDragIndex].sLabel, aDice = aComponents[nDragIndex].aDice, nMod = aComponents[nDragIndex].nMod };
-				ActionsManager.performAction(nil, nil, rRoll);
+				local rRoll = { sType = "dice", sDesc = aComponents[nDragIndex].sLabel, aDice = aComponents[nDragIndex].aDice, nMod = aComponents[nDragIndex].nMod, rStep = aComponents[nDragIndex].rStep };
+        local bSecretRoll = true;
+        --need to make sure nodeChar has the NPC actor node.
+        local nodeChar = window.getDatabaseNode();
+        local rActor = ActorManager.resolveActor(nodeChar);
+        ActionManagerED4.pushRoll(rRoll.sType, rRoll.rStep, nodeChar, bSecretRoll, rRoll);
+				--ActionsManager.performAction(nil, nil, rRoll);
 			else
 				ModifierStack.addSlot(aComponents[nDragIndex].sLabel, aComponents[nDragIndex].nMod);
 			end

--- a/common/scripts/column_number.lua
+++ b/common/scripts/column_number.lua
@@ -46,7 +46,6 @@ function update(bReadOnly, bForceHide)
 end
 
 function onValueChanged()
-  Debug.chat("Updating column_number Value");
 	if isVisible() then
 		if window.VisDataCleared then
 			if getValue() == 0 then
@@ -61,7 +60,6 @@ function onValueChanged()
 		end
 	end
   if super and super.onUpdate then
-    Debug.chat("Calling super.onUpdate");
     super.onUpdate();
   end
 end

--- a/ct/ct_host.xml
+++ b/ct/ct_host.xml
@@ -170,7 +170,25 @@
 			<button_ctentry_friendfoe name="friendfoe" />
 
       <number_ctentry_wounds name="wounds" />
-      <number_ctentry_damage name="damage" />
+      <number_ctentry_damage name="damage">
+        <delaykeyupdate />
+        <script>
+          function onValueChanged()
+            if not Global.cmUpdating then
+              Global.cmUpdating = true;
+              local rActor = ActorManager.resolveActor(DB.getParent(getDatabaseNode()));
+              if ActorManager.isPC(rActor) then
+                local dmgValue = getValue() or 0;
+                CharacterManager.updateDamage(rActor, dmgValue);
+                local nodePC = ActorManager.getCreatureNode(rActor);
+                local pcDmgTotal = DB.getValue(nodePC, "health.damage.total", 0);
+                setValue(pcDmgTotal);
+              end
+              Global.cmUpdating = false;
+            end
+          end
+        </script>
+      </number_ctentry_damage>
       <number_ctentry_threshold name="threshold" />
       <number_ctentry_unconrating name="unconrating" />
       <number_ctentry_deathrating name="deathrating" />

--- a/ct/scripts/ct_entry.lua
+++ b/ct/scripts/ct_entry.lua
@@ -155,9 +155,9 @@ function linkPCFields()
     threshold.setLink(nodeChar.createChild("health.wound.threshold", "number"), true);
     damage.setLink(nodeChar.createChild("health.damage.total", "number"));
     wounds.setLink(nodeChar.createChild("health.wounds.value", "number"));
-    phys_def.setLink(nodeChar.createChild("defenses.physical.value", "number"));
-    myst_def.setLink(nodeChar.createChild("defenses.mystic.value", "number"));
-    social_def.setLink(nodeChar.createChild("defenses.social.value", "number"));
+    phys_def.setLink(nodeChar.createChild("defenses.physical.value", "number"), true);
+    myst_def.setLink(nodeChar.createChild("defenses.mystic.value", "number"), true);
+    social_def.setLink(nodeChar.createChild("defenses.social.value", "number"), true);
 	end
 end
 
@@ -171,9 +171,9 @@ function linkNPCFields()
     threshold.setLink(nodeChar.createChild("health.wound.threshold", "number"), true);
     damage.setLink(nodeChar.createChild("health.damage.value", "number"));
     wounds.setLink(nodeChar.createChild("health.wounds.value", "number"));
-    phys_def.setLink(nodeChar.createChild("defenses.physical.value", "number"));
-    myst_def.setLink(nodeChar.createChild("defenses.mystic.value", "number"));
-    social_def.setLink(nodeChar.createChild("defenses.social.value", "number"));
+    phys_def.setLink(nodeChar.createChild("defenses.physical.value", "number"), true);
+    myst_def.setLink(nodeChar.createChild("defenses.mystic.value", "number"), true);
+    social_def.setLink(nodeChar.createChild("defenses.social.value", "number"), true);
 	end
 end
 --

--- a/scripts/manager_actions.lua
+++ b/scripts/manager_actions.lua
@@ -711,20 +711,16 @@ function createActionMessage(rSource, rRoll)
 end
 
 function total(rRoll)
-  Debug.printstack();
 	local nTotal = 0;
 
 	for _,v in ipairs(rRoll.aDice) do
 		if bUseFGUDiceValues and v.value then
-      Debug.chat("Using v.value.");
 			nTotal = nTotal + v.value;
 		else
-      Debug.chat("Using v.result.");
 			nTotal = nTotal + v.result;
 		end
 	end
 	nTotal = nTotal + rRoll.nMod;
-      Debug.chat("nTotal is: "..nTotal);
 	
 	return nTotal;
 end

--- a/scripts/manager_character.lua
+++ b/scripts/manager_character.lua
@@ -42,22 +42,21 @@ function recoveryTest(nodeChar)
   local rActor = ActorManager.resolveActor(nodeChar);
   local rStep = DB.getValue(nodeChar, "health.recovery.step", 0);
   local currentHealth = DB.getValue(nodeChar, "health.damage.total", 0);
-  local currentBlood = DB.getValue(nodeChar, "health.blood.value", 0);
-  local rType = "Recovery";
+  local currentBlood = DB.getValue(nodeChar, "health.damage.blood", 0);
+  local sType = "Recovery";
   local bSecretRoll = false;
   if currentHealth > currentBlood then
-    ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+    ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
   end
 end
 
 function rollInit(nodeChar, bSecretRoll)
   local rStep = DB.getValue(nodeChar, "initiative.step", 0);
-  local rType = "InitRoll";
-  ActionManagerED4.pushRoll(rType, rStep, nodeChar, bSecretRoll);
+  local sType = "InitRoll";
+  ActionManagerED4.pushRoll(sType, rStep, nodeChar, bSecretRoll);
 end
 
 function getKarmaStep(nodeChar)
-  Debug.printstack();
   local rActor = ActorManager.resolveActor(nodeChar);
   --Invalid Parameter for client? but only sometimes??
   local karmaStep = DB.getValue(actorPath, "karma.step", 4);
@@ -76,6 +75,29 @@ function updateMaxCarry(nodeChar)
   DB.setValue(nodeChar, "encumbrance.max", "number", maxCarry);  
 end
 
-
+function updateDamage(rActor, dmgValue)
+  if not dmgValue then
+    dmgValue = 0;
+  end
+  newDmg = 0;
+  local nodePC = ActorManager.getCreatureNode(rActor);
+  local pcDmgTotal = DB.getValue(nodePC, "health.damage.total", 0);
+  local pcDmgValue = DB.getValue(nodePC, "health.damage.value", 0);
+  local pcDmgStun = DB.getValue(nodePC, "health.damage.stun", 0);
+  local pcDmgBlood = DB.getValue(nodePC, "health.damage.blood", 0);
+  local newValue = dmgValue - pcDmgStun - pcDmgBlood;
+  if newValue < 0 then
+    newValue = 0;
+  end
+  local newTotal = newValue + pcDmgStun + pcDmgBlood;
+  if newTotal < 0 then
+    newTotal = 0;
+  end
+  if newValue ~= pcDmgValue then
+    DB.setValue(nodePC, "health.damage.value", "number", newValue);
+    DB.setValue(nodePC, "health.damage.total", "number", newTotal);
+  else
+  end
+end
 
 

--- a/scripts/step_action_lookup.lua
+++ b/scripts/step_action_lookup.lua
@@ -15,7 +15,6 @@ function getStepFromString(sInput)
   sInput = string.lower(sInput);
   local nStart, nEnd, sNumber = string.find(sInput, "%d+", 0, false);
   if nStart then
-    Debug.chat(sNumber);
     local rStep = tonumber(sNumber);
     local sDice = getStepDice(rStep);
     return rStep, sDice;
@@ -33,7 +32,6 @@ function getStepDice(stepNum)
 		stepNum = 1
 	end
 	if stepNum > 100 then
-    Debug.console("Step is Too Large, Returning Step 100.");
 		stepNum = 100;
     stepDice = getStepsHundreds(stepNum);
   return stepDice, nMod, stepNum;


### PR DESCRIPTION
June 12, 2021:
onResult now recognizes rolls that have "attack", "damage", or "heal" as part of the rRoll.sDesc.
Attack rolls now report hit or miss on physical defense.
Heal rolls now heal the target.
Damage rolls now damage the target. (normal damage only for now).
ActionManagerED4.pushRoll and ActionManagerED4.dragRoll now optionally accept a previously built rRoll.
Fixed rSource being kept from previous rolls to NPC action rolls, nil if otherwise.