### PR TITLE
GitHub Update #16

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -2,44 +2,26 @@
 TODO List
 
 CRITICALLY IMPORTANT
-
-Don't increase karma roll with step modifier box?
-Disallow/ignore Karma on skill rolls?
-Fill empty space on charsheet_main. (Blood Magic items, Half-Magic tests?)
+Leftover attribute points added to Max Karma.
 Need to create a place for Talent Knacks. Subwindow on the talents page of charsheet?
 Check for extra successes in rolls?
-Fix Talents/skills to be targetable. (add targeting features from spell page? then we only need actions tab for custom actions?)
+Fill empty space on charsheet_main? Reduce min height? (Blood Magic items, Half-Magic tests?)
 Add Thread Items Tab(s) to charsheet.
-Can I make the CT call onInit or onUpdate for combatants?
 Add spellcasting info to the top of the spells page? e.g. Spellcasting Talent, Weaving, Step, Circle (things spells need for automation)
 Make Actions tab prettier? (not needed if only custom?)
-In Progress: Fix layout of main charsheet tab. Use correct label templates (<label> and <label_frametop> but not <label_column>)
-Possibly add Circle/Novice/Journeyman to skills/talents view.
 Get Combat Tracker working. In progress, mostly working? (Need to add effect automation, etc)
-Add Racial Stats to Race records, so they can be added to character sheet by dragging. (Create New Tab?)
+In Progress: Get CT Menu working (rest, etc.) Menu is working, any new nodes to add?
+Add a script to the CT effects in ref_spells in order to separate the clauses before turning into an actual CT Effect.
 In Progress: Allow Drag/Drop Character Creation. Race/Discipline/Talents/Skills are now working.
+Add Racial Stats to Race records, so they can be added to character sheet by dragging. (Create New Tab?)
 Add Custom Ability Modifier Fields to NPC and Charsheet, to allow custom bonuses/flaws. (Other computations, such as Race, Attribute Points, Half-Magic, etc.)
 Add custom mod to entries' spellcasting tests.
-Fix layout of main charsheet tab. Use correct label templates (not label_column?)
-In Progress: Get CT Menu working (rest, etc.) Menu is working, any new nodes to add?
-Add support for new lighting features. Default visions work without modification. Possibly need to add new visions?
-Number instead of string for Strain?
-Fix NPCs so that manually entered numbers don't get overwritten by onUpdate(); (Add "Custom?" checkbox?)
-Fix modifier box not adding to "dice" rolls?
-Add note to description indicating bonus to Step #?
-Add option for removing targets on miss?
-Fix damage rolls from displaying roll total for each target.
-Update numbers in CT after rolls?
-Automate strain?
-Bypass armor option for spells?
-Leftover attribute points added to Max Karma.
-Add a script to the CT effects in ref_spells in order to separate the clauses before turning into an actual CT Effect.
-steprollfocus frame not found.
-Fix right-click-added dice not exploding?
 
 THEME/UI:
 FG Dark theme removes iedit buttons on client?
 Fix compatibility with CoreRPG themes. (probably just need to move crystal png to its own theme?)
+In Progress: Fix layout of main charsheet tab. Use correct label templates (<label> and <label_frametop> but not <label_column>)
+steprollfocus frame not found.
 
 OPTIMIZATION:
 Double Check and fix Factorization.
@@ -58,5 +40,20 @@ Figure out LibraryDataED4 (data_library_ED4.lua) I think this is related to disp
 Maybe we need a getStepFromDice function in Step_Action_Lookup? (reverse of getStepDice) (WIP)
 Fix pronouns to use they/them instead of he/him or she/her. (talent descriptions, etc) (find/replace in campaign data)
 Do I need a legend worksheet?
-Fix exploded dice to show green bgcolor instead of green die graphic for better viewing. (same for red 1/s? probably not, we know they're 1 by the color alone?)
+Fix exploded dice to show green bgcolor instead of green die graphic for better viewing. (already fixed?)
 Make NPC window narrower min width. (squish attributes closer)
+Update numbers in CT after rolls?
+Fix CT from not updating damage amounts without character/NPC sheet open.
+Can I make the CT call onInit or onUpdate for combatants?
+Add support for new lighting features. Default visions work without modification. Possibly need to add new visions?
+Automate strain?
+Number instead of string for Strain?
+Bypass armor option for spells?
+Fix right-click-added dice not exploding?
+Fix NPCs so that manually entered numbers don't get overwritten by onUpdate(); (Add "Custom?" checkbox?)
+Fix damage rolls from displaying roll total for each target.
+Fix Talents/skills to be targetable. (add targeting features from spell page? then we only need actions tab for custom actions?)
+Possibly add Circle/Novice/Journeyman to skills/talents view.
+Fix modifier box not adding to "dice" rolls?
+Add option for removing targets on miss?
+Allow NPCs to roll Recovery Tests

--- a/campaign/char_spells.xml
+++ b/campaign/char_spells.xml
@@ -13,6 +13,23 @@
 				</anchored>
 				<multilinespacing>20</multilinespacing>
 			</string_textlistitem>
+      
+			<label>
+				<anchored to="spellframe" position="insidetopright" offset="35,30" />
+				<static textres="char_label_karma" />
+			</label>
+      
+      <button_checkbox name="karmaUse" source="karma.use">
+				<anchored width="20" height="20">
+					<top offset="5" />
+					<right parent="rightanchor" anchor="left" relation="relative" offset="-25" />
+				</anchored>
+        <script>
+          function onValueChanged()
+          end
+        </script>
+      </button_checkbox>
+      
 -->
 
 <root>
@@ -133,16 +150,12 @@
 				<static textres="char_label_spellname" />
 			</label>
 			<label>
-				<anchored to="spellframe" position="insidetopright" offset="170,30" />
+				<anchored to="spellframe" position="insidetopright" offset="125,30" />
 				<static textres="char_label_casting" />
 			</label>
 			<label>
-				<anchored to="spellframe" position="insidetopright" offset="90,30" />
+				<anchored to="spellframe" position="insidetopright" offset="40,30" />
 				<static textres="char_label_effectStep" />
-			</label>
-			<label>
-				<anchored to="spellframe" position="insidetopright" offset="35,30" />
-				<static textres="char_label_karma" />
 			</label>
       
       <list_charspell name="spells">
@@ -450,16 +463,6 @@
           end
 				</script>
 			</number_charspellfield_static>
-      <button_checkbox name="karmaUse" source="karma.use">
-				<anchored width="20" height="20">
-					<top offset="5" />
-					<right parent="rightanchor" anchor="left" relation="relative" offset="-25" />
-				</anchored>
-        <script>
-          function onValueChanged()
-          end
-        </script>
-      </button_checkbox>
       <button_toggledetail name="detailButton">
 				<anchored width="20" height="20">
 					<top offset="5" />

--- a/campaign/char_talents.xml
+++ b/campaign/char_talents.xml
@@ -13,6 +13,21 @@
 				</anchored>
 				<multilinespacing>20</multilinespacing>
 			</string_textlistitem>
+      
+			<label>
+				<anchored to="talentframe" position="insidetopright" offset="35,30" />
+				<static textres="char_label_karma" />
+			</label>
+      <button_checkbox name="karmaUse" source="karma.use">
+				<anchored width="32" height="20">
+					<top offset="2" />
+					<right parent="rightanchor" anchor="left" relation="relative" offset="-15" />
+				</anchored>
+        <script>
+          function onValueChanged()
+          end
+        </script>
+      </button_checkbox>
 -->
 
 <root>
@@ -30,20 +45,16 @@
 				<static textres="char_label_talentname" />
 			</label>
 			<label>
-				<anchored to="talentframe" position="insidetopright" offset="215,30" />
+				<anchored to="talentframe" position="insidetopright" offset="165,30" />
 				<static textres="char_label_rank" />
 			</label>
 			<label>
-				<anchored to="talentframe" position="insidetopright" offset="135,30" />
+				<anchored to="talentframe" position="insidetopright" offset="85,30" />
 				<static textres="char_label_attribute" />
 			</label>
 			<label>
-				<anchored to="talentframe" position="insidetopright" offset="85,30" />
+				<anchored to="talentframe" position="insidetopright" offset="40,30" />
 				<static textres="char_label_total" />
-			</label>
-			<label>
-				<anchored to="talentframe" position="insidetopright" offset="35,30" />
-				<static textres="char_label_karma" />
 			</label>
       
       <list_chartalent name="talents">
@@ -307,16 +318,6 @@
 				</anchored>
 			</button_idelete>
       
-      <button_checkbox name="karmaUse" source="karma.use">
-				<anchored width="32" height="20">
-					<top offset="2" />
-					<right parent="rightanchor" anchor="left" relation="relative" offset="-15" />
-				</anchored>
-        <script>
-          function onValueChanged()
-          end
-        </script>
-      </button_checkbox>
       
       <number_chartalentfield name="total" source="talent.total">
 				<anchored width="32" height="20">

--- a/campaign/scripts/char_main.lua
+++ b/campaign/scripts/char_main.lua
@@ -6,13 +6,14 @@ end
 function onUpdate()
   -- This function will update all the values on the character sheet, based on the Characteristics Table (EDPG pg63)
   -- Update the Step for each Ability Value.
-  Str_Step.setValue(StepLookup.getStep(Str_Value.getValue()));  
-  Dex_Step.setValue(StepLookup.getStep(Dex_Value.getValue()));
-  Tou_Step.setValue(StepLookup.getStep(Tou_Value.getValue()));
-  Per_Step.setValue(StepLookup.getStep(Per_Value.getValue()));
-  Wil_Step.setValue(StepLookup.getStep(Wil_Value.getValue()));
-  Cha_Step.setValue(StepLookup.getStep(Cha_Value.getValue()));
-    
+  -- Add amounts in the 'Bonus' box to the base value  
+  Str_Step.setValue(StepLookup.getStep(Str_Value.getValue()+Str_Bonus.getValue()));  
+  Dex_Step.setValue(StepLookup.getStep(Dex_Value.getValue()+Dex_Bonus.getValue()));
+  Tou_Step.setValue(StepLookup.getStep(Tou_Value.getValue()+Tou_Bonus.getValue()));
+  Per_Step.setValue(StepLookup.getStep(Per_Value.getValue()+Per_Bonus.getValue()));
+  Wil_Step.setValue(StepLookup.getStep(Wil_Value.getValue()+Wil_Bonus.getValue()));
+  Cha_Step.setValue(StepLookup.getStep(Cha_Value.getValue()+Cha_Bonus.getValue()));
+  
   --Update Characteristics (Table (EDPG pg63))
   local charRace = race.getValue();
   local racialArmor = 0;

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,6 +4,12 @@ This means that I will no longer be testing this ruleset in FGC. I can only guar
 
 FINISHED/FIXED:
 
+GitHub Update #16
+October 18, 2021
+Removed deprecated Karma boxes on Talents and Spells sheets.
+Fixed character attribute bonus to add to attribute value before checking step number.
+Fixed NPCs to allow typing damage directly into CT. (stun damage still uses NPC sheet).
+
 GitHub Update #15
 August 31, 2021
 Updated Git authentication.

--- a/ct/ct_host.xml
+++ b/ct/ct_host.xml
@@ -177,7 +177,7 @@
             if not Global.cmUpdating then
               Global.cmUpdating = true;
               local rActor = ActorManager.resolveActor(DB.getParent(getDatabaseNode()));
-              if ActorManager.isPC(rActor) then
+              if true then
                 local dmgValue = getValue() or 0;
                 CharacterManager.updateDamage(rActor, dmgValue);
                 local nodePC = ActorManager.getCreatureNode(rActor);


### PR DESCRIPTION
October 18, 2021
Removed deprecated Karma boxes on Talents and Spells sheets.
Fixed character attribute bonus to add to attribute value before checking step number.
Fixed NPCs to allow typing damage directly into CT. (stun damage still uses NPC sheet).